### PR TITLE
OTT-3623: blocking the ubuntu upgrade to 16.04

### DIFF
--- a/tasks/install_utilities.yml
+++ b/tasks/install_utilities.yml
@@ -13,9 +13,9 @@
 - name: install utilities from apt
   apt: name={{ item }} state=present
   with_items:
-    - jq=1.4-2.1~ubuntu14.04.1
+    - jq
     - htop
-    - mysql-client-5.6
+    - mysql-client
     - mysql-utilities
     - python-mysqldb
     - curl


### PR DESCRIPTION
we depend on jql, mysql-client versions only available in 14.04.
Remove specific version and install the latest version.
